### PR TITLE
Camera: made one world unit equal to one tile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bevy_survival_crafting_game"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy-inspector-egui",
+ "ron",
+ "serde",
+]
+
+[[package]]
 name = "bevy_tasks"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1976,16 +1986,6 @@ checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
 dependencies = [
  "libc",
  "pkg-config",
-]
-
-[[package]]
-name = "live_coding_1"
-version = "0.1.0"
-dependencies = [
- "bevy",
- "bevy-inspector-egui",
- "ron",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "live_coding_1"
+name = "bevy_survival_crafting_game"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/assets.rs
+++ b/src/assets.rs
@@ -53,9 +53,9 @@ impl Plugin for GameAssetsPlugin {
     }
 }
 
-pub const RESOLUTION: f32 = 16.0 / 9.0;
-//Three pixels divided by half of the screen height
-pub const PIXEL_SIZE: f32 = 3. / 450.;
+pub const PIXEL_SCALE: f32 = 3.;
+pub const SOURCE_TILE_SIZE: f32 = 32.;
+pub const TILE_SIZE: f32 = SOURCE_TILE_SIZE * PIXEL_SCALE;
 
 pub struct Graphics {
     pub texture_atlas: Handle<TextureAtlas>,
@@ -89,8 +89,8 @@ impl GameAssetsPlugin {
 
             //Set the size to be proportional to the source rectangle
             sprite.custom_size = Some(Vec2::new(
-                rect.size.0 * PIXEL_SIZE,
-                rect.size.1 * PIXEL_SIZE,
+                rect.size.0 / SOURCE_TILE_SIZE,
+                rect.size.1 / SOURCE_TILE_SIZE,
             ));
 
             //Position the sprite anchor if one is defined

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -176,11 +176,7 @@ impl CraftingPlugin {
                     .spawn_bundle(SpriteSheetBundle {
                         sprite: sprite.clone(),
                         texture_atlas: graphics.texture_atlas.clone(),
-                        transform: Transform::from_xyz(
-                            -7.5,
-                            starting_y - i as f32,
-                            -1.0,
-                        ),
+                        transform: Transform::from_xyz(-7.5, starting_y - i as f32, -1.0),
                         ..Default::default()
                     })
                     .insert(CraftingBox {

--- a/src/crafting.rs
+++ b/src/crafting.rs
@@ -11,9 +11,6 @@ pub struct CraftingBox {
     recipe_index: usize,
 }
 
-//FIXME this has no real connection to the box size
-pub const CRAFTING_BOX_SIZE: f32 = 0.1;
-
 pub struct CraftingBook {
     pub(crate) recipes: Vec<CraftingRecipe>,
 }
@@ -78,10 +75,11 @@ impl CraftingPlugin {
             assert!(transform.scale == Vec3::splat(1.0));
             let translation = transform.translation;
             //TODO use bevy aabb collide method
-            if !(mouse_pos.0.x > translation.x - 0.5 * CRAFTING_BOX_SIZE
-                && mouse_pos.0.x < translation.x + 0.5 * CRAFTING_BOX_SIZE
-                && mouse_pos.0.y > translation.y - 0.5 * CRAFTING_BOX_SIZE
-                && mouse_pos.0.y < translation.y + 0.5 * CRAFTING_BOX_SIZE)
+            // 80% of the dimensions of the box, that's 0.4 in either direction
+            if !(mouse_pos.0.x > translation.x - 0.4
+                && mouse_pos.0.x < translation.x + 0.4
+                && mouse_pos.0.y > translation.y - 0.4
+                && mouse_pos.0.y < translation.y + 0.4)
             {
                 continue;
             }
@@ -163,12 +161,10 @@ impl CraftingPlugin {
     ) {
         let camera_ent = camera_query.single();
 
-        let spacing = 0.20;
-
-        let starting_y = (book.recipes.len() as f32 / 2.0 + 0.5) * spacing;
+        let starting_y = book.recipes.len() as f32 / 2.0 - 0.5;
 
         let mut sprite = TextureAtlasSprite::new(graphics.box_index);
-        sprite.custom_size = Some(Vec2::splat(PIXEL_SIZE * 32.));
+        sprite.custom_size = Some(Vec2::splat(1.));
 
         //could enumerate book
         let boxes: Vec<Entity> = book
@@ -181,8 +177,8 @@ impl CraftingPlugin {
                         sprite: sprite.clone(),
                         texture_atlas: graphics.texture_atlas.clone(),
                         transform: Transform::from_xyz(
-                            -0.9 * RESOLUTION,
-                            starting_y - spacing * i as f32,
+                            -7.5,
+                            starting_y - i as f32,
                             -1.0,
                         ),
                         ..Default::default()

--- a/src/game_camera.rs
+++ b/src/game_camera.rs
@@ -1,4 +1,5 @@
 use crate::prelude::{Player, TILE_SIZE};
+use crate::{HEIGHT, RESOLUTION};
 use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
 
@@ -17,7 +18,7 @@ impl Plugin for GameCameraPlugin {
             //The camera transform should update its position after all other transforms to prevent non-deterministic behavior and jitter
             //For example, without this, some times you run the game the player will be visibly rendered in the wrong position when moving
             CoreStage::PostUpdate,
-            Self::camera_follow
+            Self::camera_follow,
         );
     }
 }
@@ -29,8 +30,11 @@ impl GameCameraPlugin {
         let mut camera = OrthographicCameraBundle::new_2d();
 
         // One unit in world space is one tile
-        camera.orthographic_projection.scale = 1. / TILE_SIZE;
-        camera.orthographic_projection.scaling_mode = ScalingMode::WindowSize;
+        camera.orthographic_projection.left = -HEIGHT / TILE_SIZE / 2.0 * RESOLUTION;
+        camera.orthographic_projection.right = HEIGHT / TILE_SIZE / 2.0 * RESOLUTION;
+        camera.orthographic_projection.top = HEIGHT / TILE_SIZE / 2.0;
+        camera.orthographic_projection.bottom = -HEIGHT / TILE_SIZE / 2.0;
+        camera.orthographic_projection.scaling_mode = ScalingMode::None;
 
         commands.spawn_bundle(camera).insert(GameCamera);
     }

--- a/src/game_camera.rs
+++ b/src/game_camera.rs
@@ -1,4 +1,4 @@
-use crate::prelude::{Player, RESOLUTION};
+use crate::prelude::{Player, TILE_SIZE};
 use bevy::prelude::*;
 use bevy::render::camera::ScalingMode;
 
@@ -14,7 +14,8 @@ impl Plugin for GameCameraPlugin {
             Self::spawn_camera.label("camera"),
         )
         .add_system_to_stage(
-            //The camera should update after all other game systems to enforce determinism and prevent jittering
+            //The camera transform should update its position after all other transforms to prevent non-deterministic behavior and jitter
+            //For example, without this, some times you run the game the player will be visibly rendered in the wrong position when moving
             CoreStage::PostUpdate,
             Self::camera_follow
         );
@@ -26,11 +27,10 @@ impl GameCameraPlugin {
         commands.spawn_bundle(UiCameraBundle::default());
 
         let mut camera = OrthographicCameraBundle::new_2d();
-        camera.orthographic_projection.left = -1.0 * RESOLUTION;
-        camera.orthographic_projection.right = 1.0 * RESOLUTION;
-        camera.orthographic_projection.top = 1.0;
-        camera.orthographic_projection.bottom = -1.0;
-        camera.orthographic_projection.scaling_mode = ScalingMode::None;
+
+        // One unit in world space is one tile
+        camera.orthographic_projection.scale = 1. / TILE_SIZE;
+        camera.orthographic_projection.scaling_mode = ScalingMode::WindowSize;
 
         commands.spawn_bundle(camera).insert(GameCamera);
     }

--- a/src/game_camera.rs
+++ b/src/game_camera.rs
@@ -13,7 +13,11 @@ impl Plugin for GameCameraPlugin {
             StartupStage::PreStartup,
             Self::spawn_camera.label("camera"),
         )
-        .add_system(Self::camera_follow);
+        .add_system_to_stage(
+            //The camera should update after all other game systems to enforce determinism and prevent jittering
+            CoreStage::PostUpdate,
+            Self::camera_follow
+        );
     }
 }
 

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -206,7 +206,8 @@ fn spawn_inventory_ui(
     let text_x_offset_percent = spacing_percent * 0.7;
 
     let starting_x = -(INVENTORY_SIZE as f32) / 2. + 0.5;
-    let starting_percent = 50. - (INVENTORY_SIZE as f32 * spacing_percent / 2.) + text_x_offset_percent;
+    let starting_percent =
+        50. - (INVENTORY_SIZE as f32 * spacing_percent / 2.) + text_x_offset_percent;
 
     let mut sprite = TextureAtlasSprite::new(graphics.box_index);
     sprite.custom_size = Some(Vec2::splat(1.));

--- a/src/inventory.rs
+++ b/src/inventory.rs
@@ -3,7 +3,7 @@ use bevy_inspector_egui::{Inspectable, RegisterInspectable};
 
 use crate::{
     item::{ItemAndCount, WorldObject},
-    prelude::{GameCamera, GameError, GameErrorType, Graphics, ItemType, PIXEL_SIZE, RESOLUTION},
+    prelude::{GameCamera, GameError, GameErrorType, Graphics, ItemType, TILE_SIZE},
 };
 
 pub const INVENTORY_SIZE: usize = 5;
@@ -199,14 +199,17 @@ fn spawn_inventory_ui(
     let mut boxes = Vec::new();
     let mut ui_texts = Vec::new();
 
-    let spacing = 0.20;
-    let spacing_percent = spacing / 2.0 / RESOLUTION * 100.0;
+    //Spacing is one unit in pixels divided by one percent of the window width in pixels
+    let spacing_percent = TILE_SIZE / 1600. * 100.;
 
-    let starting_x = (-(INVENTORY_SIZE as f32) / 2.0 + 0.5) * spacing;
-    let starting_percent = (0.5 + starting_x / 2.0 / RESOLUTION) * 100.0 + 0.9;
+    //Used to offset the inventory count text to place it in the corner of the box
+    let text_x_offset_percent = spacing_percent * 0.7;
+
+    let starting_x = -(INVENTORY_SIZE as f32) / 2. + 0.5;
+    let starting_percent = 50. - (INVENTORY_SIZE as f32 * spacing_percent / 2.) + text_x_offset_percent;
 
     let mut sprite = TextureAtlasSprite::new(graphics.box_index);
-    sprite.custom_size = Some(Vec2::splat(PIXEL_SIZE * 32.));
+    sprite.custom_size = Some(Vec2::splat(1.));
 
     for i in 0..INVENTORY_SIZE {
         ui_texts.push(
@@ -216,7 +219,7 @@ fn spawn_inventory_ui(
                         align_self: AlignSelf::Auto,
                         position_type: PositionType::Absolute,
                         position: Rect {
-                            bottom: Val::Percent(7.0),
+                            bottom: Val::Percent(4.0),
                             left: Val::Percent(starting_percent + spacing_percent * i as f32),
                             ..Default::default()
                         },
@@ -248,7 +251,7 @@ fn spawn_inventory_ui(
                     sprite: sprite.clone(),
                     texture_atlas: graphics.texture_atlas.clone(),
                     transform: Transform {
-                        translation: Vec3::new(starting_x + spacing * i as f32, -0.8, -1.0),
+                        translation: Vec3::new(starting_x + i as f32, -4.0, -1.0),
                         ..Default::default()
                     },
                     ..Default::default()

--- a/src/item.rs
+++ b/src/item.rs
@@ -211,41 +211,25 @@ impl ItemsPlugin {
     #[allow(clippy::vec_init_then_push)]
     fn spawn_test_objects(mut commands: Commands, graphics: Res<Graphics>) {
         let mut children = Vec::new();
-        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-0.6, 0.6)));
-        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-0.6, 0.3)));
-        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-0.3, 0.6)));
-        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-0.3, 0.3)));
+        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-3., 3.)));
+        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-3., 1.)));
+        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-1., 3.)));
+        children.push(WorldObject::Sapling.spawn(&mut commands, &graphics, Vec2::new(-1., 1.)));
 
-        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(0.6, -0.6)));
-        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(0.6, -0.3)));
-        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(0.3, -0.6)));
-        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(0.3, -0.3)));
+        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(3., -3.)));
+        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(3., -1.)));
+        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(1., -3.)));
+        children.push(WorldObject::Grass.spawn(&mut commands, &graphics, Vec2::new(1., -1.)));
 
-        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-0.6, -0.6)));
-        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-0.6, -0.3)));
-        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-0.3, -0.6)));
-        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-0.3, -0.3)));
+        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-3., -3.)));
+        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-3., -1.)));
+        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-1., -3.)));
+        children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-1., -1.)));
 
-        children.push(WorldObject::Item(ItemType::Flint).spawn(
-            &mut commands,
-            &graphics,
-            Vec2::new(0.4, 0.4),
-        ));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(
-            &mut commands,
-            &graphics,
-            Vec2::new(0.4, 0.3),
-        ));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(
-            &mut commands,
-            &graphics,
-            Vec2::new(0.3, 0.4),
-        ));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(
-            &mut commands,
-            &graphics,
-            Vec2::new(0.3, 0.3),
-        ));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(3., 3.)));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(3., 1.)));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(1., 3.)));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(1., 1.)));
         commands
             .spawn_bundle(TransformBundle::default())
             .insert(Name::new("Test Objects"))

--- a/src/item.rs
+++ b/src/item.rs
@@ -226,10 +226,26 @@ impl ItemsPlugin {
         children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-1., -3.)));
         children.push(WorldObject::Tree.spawn(&mut commands, &graphics, Vec2::new(-1., -1.)));
 
-        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(3., 3.)));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(3., 1.)));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(1., 3.)));
-        children.push(WorldObject::Item(ItemType::Flint).spawn(&mut commands, &graphics, Vec2::new(1., 1.)));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(
+            &mut commands,
+            &graphics,
+            Vec2::new(3., 3.),
+        ));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(
+            &mut commands,
+            &graphics,
+            Vec2::new(3., 1.),
+        ));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(
+            &mut commands,
+            &graphics,
+            Vec2::new(1., 3.),
+        ));
+        children.push(WorldObject::Item(ItemType::Flint).spawn(
+            &mut commands,
+            &graphics,
+            Vec2::new(1., 1.),
+        ));
         commands
             .spawn_bundle(TransformBundle::default())
             .insert(Name::new("Test Objects"))

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,12 +20,15 @@ use prelude::{
     CraftingPlugin, GameAssetsPlugin, GameCameraPlugin, InventoryPlugin, ItemsPlugin, PlayerPlugin,
 };
 
+pub const HEIGHT: f32 = 900.;
+pub const RESOLUTION: f32 = 16.0 / 9.0;
+
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::hex("b0c060").unwrap()))
         .insert_resource(WindowDescriptor {
-            width: 1600.0,
-            height: 900.0,
+            width: HEIGHT * RESOLUTION,
+            height: HEIGHT,
             title: "DST clone".to_string(),
             present_mode: PresentMode::Fifo,
             resizable: false,

--- a/src/player.rs
+++ b/src/player.rs
@@ -55,10 +55,13 @@ impl PlayerPlugin {
                         warn!("{:?}", error);
                     };
                     if let Some(tool) = hands.left {
-                        if inventory.add(&ItemAndCount {
-                            item: ItemType::Tool(tool),
-                            count: 1,
-                        }).is_some() {
+                        if inventory
+                            .add(&ItemAndCount {
+                                item: ItemType::Tool(tool),
+                                count: 1,
+                            })
+                            .is_some()
+                        {
                             //FIXME removing what was in hand might not be able to go back into inventory
                             warn!("Item was lost! on unequip");
                         }

--- a/src/player.rs
+++ b/src/player.rs
@@ -1,4 +1,4 @@
-use crate::{crafting::CRAFTING_BOX_SIZE, inventory::InventoryBox, prelude::PIXEL_SIZE};
+use crate::inventory::InventoryBox;
 use bevy::prelude::*;
 use bevy::sprite::Anchor;
 use bevy_inspector_egui::{Inspectable, RegisterInspectable};
@@ -39,11 +39,11 @@ impl PlayerPlugin {
         let (_, mut inventory, mut hands) = player_query.single_mut();
         if mouse.just_pressed(MouseButton::Left) {
             for (transform, inv_box) in inventory_boxes.iter() {
-                //FIXME this uses a magic number, is there a better way
-                if !(mouse_pos.0.x > transform.translation.x - 0.5 * CRAFTING_BOX_SIZE
-                    && mouse_pos.0.x < transform.translation.x + 0.5 * CRAFTING_BOX_SIZE
-                    && mouse_pos.0.y > transform.translation.y - 0.5 * CRAFTING_BOX_SIZE
-                    && mouse_pos.0.y < transform.translation.y + 0.5 * CRAFTING_BOX_SIZE)
+                // 80% of the dimensions of the box, that's 0.4 in either direction
+                if !(mouse_pos.0.x > transform.translation.x - 0.4
+                    && mouse_pos.0.x < transform.translation.x + 0.4
+                    && mouse_pos.0.y > transform.translation.y - 0.4
+                    && mouse_pos.0.y < transform.translation.y + 0.4)
                 {
                     continue;
                 }
@@ -171,7 +171,7 @@ impl PlayerPlugin {
 
     fn spawn_player(mut commands: Commands, graphics: Res<Graphics>) {
         let mut sprite = TextureAtlasSprite::new(graphics.player_index);
-        sprite.custom_size = Some(Vec2::splat(PIXEL_SIZE * 32.0));
+        sprite.custom_size = Some(Vec2::splat(1.));
         sprite.anchor = Anchor::Custom(Vec2::new(0.0, 0.5 - 30.0 / 32.0));
         commands
             .spawn_bundle(SpriteSheetBundle {
@@ -184,8 +184,8 @@ impl PlayerPlugin {
                 ..Default::default()
             })
             .insert(Player {
-                speed: 0.3,
-                arm_length: 0.1,
+                speed: 3.0,
+                arm_length: 1.0,
             })
             .insert(Inventory::default())
             .insert(Hands::default())

--- a/src/player.rs
+++ b/src/player.rs
@@ -36,7 +36,7 @@ impl PlayerPlugin {
         mouse: Res<Input<MouseButton>>,
         mouse_pos: Res<MousePosition>,
     ) {
-        let (player, mut inventory, mut hands) = player_query.single_mut();
+        let (_, mut inventory, mut hands) = player_query.single_mut();
         if mouse.just_pressed(MouseButton::Left) {
             for (transform, inv_box) in inventory_boxes.iter() {
                 //FIXME this uses a magic number, is there a better way
@@ -55,10 +55,10 @@ impl PlayerPlugin {
                         warn!("{:?}", error);
                     };
                     if let Some(tool) = hands.left {
-                        if let Some(_) = inventory.add(&ItemAndCount {
+                        if inventory.add(&ItemAndCount {
                             item: ItemType::Tool(tool),
                             count: 1,
-                        }) {
+                        }).is_some() {
                             //FIXME removing what was in hand might not be able to go back into inventory
                             warn!("Item was lost! on unequip");
                         }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,5 @@
 use crate::assets;
-pub use assets::{GameAssetsPlugin, Graphics, PIXEL_SIZE, RESOLUTION};
+pub use assets::{GameAssetsPlugin, Graphics, TILE_SIZE};
 
 use crate::crafting;
 pub use crafting::CraftingPlugin;


### PR DESCRIPTION
This change aims to make it easier to reason about size and distance and to avoid magic numbers.
Additionally the camera's movement has been moved to the PostUpdate stage to prevent some unpredictable behavior.